### PR TITLE
Extend build timeouts from 2 mins to 5 mins

### DIFF
--- a/routes/project.js
+++ b/routes/project.js
@@ -22,6 +22,7 @@ var fs = require("fs"),
 module.exports = {
 
     get: function (req, res) {
+        req.connection.setTimeout(300000); // 5 mins
         var projectPath = req.query.path,
             cmd = apiUtil.getPlatformProjectCommand(projectPath, req.query.cmd),
             args = req.query.args,


### PR DESCRIPTION
Took a while to find this one: https://groups.google.com/forum/#!topic/nodejs/XVCPJQPEoJI
